### PR TITLE
Task 3

### DIFF
--- a/notebooks/new_correlation_analysis.ipynb
+++ b/notebooks/new_correlation_analysis.ipynb
@@ -1,0 +1,160 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "d709e7de",
+   "metadata": {},
+   "source": [
+    "# 1. Import"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e5535e1b",
+   "metadata": {
+    "vscode": {
+     "languageId": "plaintext"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plt\n",
+    "from scripts.news_sentiment import load_news_data, compute_sentiment, daily_avg_sentiment\n",
+    "from scripts.correlation_utils import compute_daily_returns, merge_sentiment_and_returns, calculate_correlation\n",
+    "from scripts.stock_utils import get_stock_data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a4632786",
+   "metadata": {},
+   "source": [
+    "\n",
+    "# 2. Load News + Score Sentiment"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2b1fa276",
+   "metadata": {
+    "vscode": {
+     "languageId": "plaintext"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "news_df = load_news_data('data/news_headlines.csv')\n",
+    "news_df = compute_sentiment(news_df)\n",
+    "daily_sentiment = daily_avg_sentiment(news_df)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1e1e21ba",
+   "metadata": {},
+   "source": [
+    "\n",
+    "# 3. Load Stock Data and Compute Daily Returns"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0fba4cd8",
+   "metadata": {
+    "vscode": {
+     "languageId": "plaintext"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "stock_df = get_stock_data('AAPL', start='2023-01-01', end='2024-01-01')\n",
+    "stock_df = compute_daily_returns(stock_df)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "766d43cd",
+   "metadata": {},
+   "source": [
+    "\n",
+    "# 4. Merge and Correlate"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d11ff996",
+   "metadata": {
+    "vscode": {
+     "languageId": "plaintext"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "merged_df = merge_sentiment_and_returns(daily_sentiment, stock_df)\n",
+    "corr = calculate_correlation(merged_df)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "167ceb28",
+   "metadata": {},
+   "source": [
+    "# 5. Plot"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "99177050",
+   "metadata": {
+    "vscode": {
+     "languageId": "plaintext"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(12, 5))\n",
+    "plt.scatter(merged_df['Sentiment'], merged_df['Daily Return'], alpha=0.6)\n",
+    "plt.title(f'Sentiment vs Daily Return (Correlation = {corr:.2f})')\n",
+    "plt.xlabel('Sentiment Score')\n",
+    "plt.ylabel('Daily Stock Return')\n",
+    "plt.grid(True)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b4f01155",
+   "metadata": {},
+   "source": [
+    "# 6. Display Summary"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dcdea287",
+   "metadata": {
+    "vscode": {
+     "languageId": "plaintext"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "print(f\"Pearson Correlation: {corr:.4f}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,10 @@ numpy
 matplotlib
 seaborn
 pytest
+ta-lib
+y-finance
+pynance
+jupyterlab
+scilit-learn
+nltk
+textblob

--- a/scripts/correlation_util.py
+++ b/scripts/correlation_util.py
@@ -1,0 +1,18 @@
+# scripts/correlation_utils.py
+
+import pandas as pd
+
+
+def compute_daily_returns(df):
+    df['Daily Return'] = df['Close'].pct_change()
+    df['Date'] = df.index.date
+    return df
+
+
+def merge_sentiment_and_returns(sentiment_df, returns_df):
+    merged = pd.merge(sentiment_df, returns_df[['Date', 'Daily Return']], on='Date', how='inner')
+    return merged
+
+
+def calculate_correlation(merged_df):
+    return merged_df['Sentiment'].corr(merged_df['Daily Return'])

--- a/scripts/new_sentiment.py
+++ b/scripts/new_sentiment.py
@@ -1,0 +1,22 @@
+# scripts/news_sentiment.py
+
+import pandas as pd
+from textblob import TextBlob
+
+
+def load_news_data(path):
+    df = pd.read_csv(path, parse_dates=['Date'])
+    df['Date'] = pd.to_datetime(df['Date']).dt.date
+    return df
+
+
+def compute_sentiment(df):
+    def get_sentiment(text):
+        return TextBlob(text).sentiment.polarity
+
+    df['Sentiment'] = df['Headline'].astype(str).apply(get_sentiment)
+    return df
+
+
+def daily_avg_sentiment(df):
+    return df.groupby('Date')['Sentiment'].mean().reset_index()

--- a/scripts/ta_utils.py
+++ b/scripts/ta_utils.py
@@ -1,0 +1,10 @@
+import talib
+
+def add_technical_indicators(df):
+    df['SMA_20'] = talib.SMA(df['Close'], timeperiod=20)
+    df['EMA_20'] = talib.EMA(df['Close'], timeperiod=20)
+    df['RSI_14'] = talib.RSI(df['Close'], timeperiod=14)
+    macd, macdsignal, _ = talib.MACD(df['Close'], fastperiod=12, slowperiod=26, signalperiod=9)
+    df['MACD'] = macd
+    df['MACD_Signal'] = macdsignal
+    return df


### PR DESCRIPTION
This pull request introduces a new notebook for correlation analysis between news sentiment and stock returns, along with supporting utility scripts for sentiment analysis, correlation computation, and technical indicator calculations. The changes are structured to provide a streamlined workflow for data analysis and visualization.

### Notebook for Correlation Analysis:
* [`notebooks/new_correlation_analysis.ipynb`](diffhunk://#diff-ccb6191ddc5bed92acdf93c7820bf7f7b7944b96397dce6c72b25185a5feff8cR1-R160): Added a new Jupyter notebook that demonstrates the workflow for analyzing the correlation between news sentiment and stock returns. It includes steps for importing libraries, loading and processing data, computing sentiment and daily returns, merging datasets, calculating correlation, and visualizing results.

### Utilities for Sentiment Analysis:
* [`scripts/news_sentiment.py`](diffhunk://#diff-12ba90cd55c5deb832789b787e7954166081258f8d4e8cec816d232bddda150bR1-R22): Added functions to load news data, compute sentiment using TextBlob, and calculate daily average sentiment scores. These utilities enable sentiment analysis of news headlines.

### Utilities for Correlation Computation:
* [`scripts/correlation_utils.py`](diffhunk://#diff-2c850381d302276eae8eefe2e2895b217da13ea6ba7af143dc335207b5a1b5cdR1-R18): Added functions to compute daily stock returns, merge sentiment and returns data, and calculate the Pearson correlation between sentiment scores and daily returns. These utilities support the analysis workflow.

### Technical Indicators:
* [`scripts/ta_utils.py`](diffhunk://#diff-fd89db069fea0008e314c9cb4f4122f40b094d4b089bb8f3f6abf5f3ea3d1423R1-R10): Added functions to compute technical indicators such as SMA, EMA, RSI, and MACD using the TA-Lib library. These indicators can be used for further stock analysis.